### PR TITLE
fix: make FrameCounter::next fallible to prevent counter/nonce reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ let payload = "Something secret";
 
 let mut encrypt_buffer = Vec::new();
 let mut decrypt_buffer = Vec::new();
-let media_frame = MediaFrameView::new(&mut counter, payload);
+let media_frame = MediaFrameView::new(&mut counter, payload).unwrap();
 
 let encrypted_frame = media_frame.encrypt_into(&enc_key, &mut encrypt_buffer).unwrap();
 

--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -65,7 +65,7 @@ impl CryptoBenches {
                     || create_random_media_frame(payload_size),
                     |unencrypted_payload| {
                         let media_frame =
-                            MediaFrameView::new(&mut self.counter, &unencrypted_payload);
+                            MediaFrameView::new(&mut self.counter, &unencrypted_payload).unwrap();
                         let encrypted_frame = media_frame
                             .encrypt_into(&self.enc_key, &mut self.crypt_buffer)
                             .unwrap();
@@ -122,7 +122,7 @@ fn create_random_media_frame(size: usize) -> MediaFrame {
     let mut unencrypted_payload = vec![0; size];
     rng().fill(unencrypted_payload.as_mut_slice());
     let mut counter = MonotonicCounter::new(rng().random::<Counter>());
-    MediaFrame::new(&mut counter, unencrypted_payload)
+    MediaFrame::new(&mut counter, unencrypted_payload).unwrap()
 }
 
 fn encrypt_random_frame(
@@ -131,7 +131,7 @@ fn encrypt_random_frame(
     enc_key: &EncryptionKey,
 ) -> EncryptedFrame {
     let unencrypted_payload = create_random_media_frame(size);
-    let media_frame = MediaFrameView::new(counter, &unencrypted_payload);
+    let media_frame = MediaFrameView::new(counter, &unencrypted_payload).unwrap();
     media_frame.encrypt(enc_key).unwrap()
 }
 

--- a/examples/bip_frame_buffer.rs
+++ b/examples/bip_frame_buffer.rs
@@ -96,14 +96,20 @@ fn producer_task(producer: FramedProducer<&'static Churrasco<BUF_SIZE>>) {
             payload
         );
 
-        let media_frame = MediaFrameView::new(&mut counter, &payload);
-
-        if let Err(err) = media_frame.encrypt_into(&key, &mut buffer) {
-            println!(
-                "[Producer] Failed to encrypt frame # {} due to {}",
-                counter.current(),
-                err
-            );
+        match MediaFrameView::new(&mut counter, &payload) {
+            Ok(media_frame) => {
+                if let Err(err) = media_frame.encrypt_into(&key, &mut buffer) {
+                    println!(
+                        "[Producer] Failed to encrypt frame # {} due to {}",
+                        counter.current(),
+                        err
+                    );
+                }
+            }
+            Err(err) => {
+                println!("[Producer] Failed to create frame due to {}", err);
+                break;
+            }
         }
 
         buffer.commit();

--- a/examples/caesar_cipher.rs
+++ b/examples/caesar_cipher.rs
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
     println!("Original: {:?}", original_data);
 
     let mut counter = MonotonicCounter::default();
-    let media_frame = MediaFrame::new(&mut counter, original_data);
+    let media_frame = MediaFrame::new(&mut counter, original_data)?;
 
     let encrypted_frame = media_frame.encrypt(&enc_key)?;
     println!(

--- a/examples/sender_receiver/sender.rs
+++ b/examples/sender_receiver/sender.rs
@@ -86,7 +86,8 @@ impl Sender {
 
             let payload = &unencrypted_frame[skip..];
             let meta_data = &unencrypted_frame[..skip];
-            let media_frame = MediaFrameView::with_meta_data(&mut self.counter, payload, meta_data);
+            let media_frame =
+                MediaFrameView::with_meta_data(&mut self.counter, payload, meta_data)?;
 
             media_frame.encrypt_into(enc_key, &mut self.buffer)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,13 @@ pub enum SframeError {
     #[error("{0}")]
     FrameValidationFailed(String),
 
+    /// the frame counter (CTR) has been exhausted for the current (base key, KID) and must not
+    /// be reused, see [RFC 9605 9.1](https://www.rfc-editor.org/rfc/rfc9605.html#name-header-value-uniqueness)
+    #[error(
+        "Frame counter has been exhausted, rotate the key/KID before encrypting further frames"
+    )]
+    CounterExhausted,
+
     /// buffer was too small to deserialize into/ serialize from
     #[error("buffer with size {0} is too small")]
     InvalidBuffer(usize),

--- a/src/frame/frame_counter.rs
+++ b/src/frame/frame_counter.rs
@@ -5,55 +5,111 @@ use crate::header::Counter;
 /// It is crutial that a unique combination of (base key, KID, CTR) is used for each encryption
 /// operation to prevent reusing the  same key and nonce of the underlying AEAD algorithm.
 /// ,see [RFC 9605 9.1](https://www.rfc-editor.org/rfc/rfc9605.html#name-header-value-uniqueness)
-/// ** This is not enforced by this library.**
 pub trait FrameCounter {
-    /// Returns the next counter value. Must be unique for each encryption operation (with the same
-    /// base key & KID).
-    fn next(&mut self) -> Counter;
+    /// Returns the next counter value, unique for each encryption operation (with the same
+    /// base key & KID). Returns `None` once the counter space is exhausted, e.g. by an
+    /// overflow, in which case the caller must not encrypt any further frame with the current
+    /// (base key, KID) - see [`crate::error::SframeError::CounterExhausted`].
+    fn next(&mut self) -> Option<Counter>;
 }
 
 #[derive(Copy, Clone, Debug)]
-/// A simple counter that increases by one for each call to `next()` up to a fixed limit, where it
-/// wraps around. Per Default the limit is `u64::MAX`.
+/// A simple counter that increases by one for each call to `next()` up to a fixed limit.
+/// Per default the limit is `u64::MAX` and the counter is exhausted (returning `None`) once
+/// that limit has been handed out, instead of silently wrapping back to `0` - reusing a counter
+/// under the same (base key, KID) would break confidentiality of the AEAD scheme.
+///
+/// Wrapping around can be opted into explicitly via [`MonotonicCounter::allow_overrun`], e.g.
+/// when the caller can independently guarantee that the (base key, KID) is rotated before the
+/// counter space is exhausted.
 pub struct MonotonicCounter {
     current_counter: u64,
     max_counter: u64,
+    allow_overrun: bool,
+    exhausted: bool,
 }
 
 impl MonotonicCounter {
-    /// Creates a new counter which will wrap around after `max_counter` was reached.
+    /// Creates a new counter which will be exhausted after `max_counter` was reached.
     pub fn new(max_counter: u64) -> Self {
         Self {
             current_counter: 0,
             max_counter,
+            allow_overrun: false,
+            exhausted: false,
         }
     }
 
-    /// Creates a new counter with a start value which will wrap around after `max_counter` was
+    /// Creates a new counter with a start value which will be exhausted after `max_counter` was
     /// reached.
     pub fn with_start_value(start_value: u64, max_counter: u64) -> Self {
         Self {
             current_counter: start_value,
             max_counter,
+            allow_overrun: false,
+            exhausted: false,
         }
+    }
+
+    /// Configures whether the counter is allowed to wrap around to `0` after `max_counter` was
+    /// reached, instead of being exhausted.
+    /// # Warning
+    /// Only enable this if the (base key, KID) is guaranteed to be rotated before the counter
+    /// wraps, otherwise the same (base key, KID, CTR) combination will be reused, breaking
+    /// confidentiality of the AEAD scheme, see [RFC 9605 9.1](https://www.rfc-editor.org/rfc/rfc9605.html#name-header-value-uniqueness).
+    pub fn allow_overrun(mut self, allow_overrun: bool) -> Self {
+        self.allow_overrun = allow_overrun;
+        self
     }
 
     /// Returns the current counter value.
     pub fn current(&self) -> Counter {
         self.current_counter
     }
+
+    /// Returns whether the counter is exhausted, i.e. further calls to `next()` will return
+    /// `None`.
+    pub fn is_exhausted(&self) -> bool {
+        self.exhausted
+    }
+
+    /// Resets the counter to `0` and clears the exhausted state.
+    /// # Warning
+    /// This must only be done after switching to a new (base key, KID), otherwise a previously
+    /// used counter value could be handed out again under the same (base key, KID).
+    pub fn reset(&mut self) {
+        self.reset_to(0);
+    }
+
+    /// Resets the counter to `start_value` and clears the exhausted state.
+    /// # Warning
+    /// This must only be done after switching to a new (base key, KID), otherwise a previously
+    /// used counter value could be handed out again under the same (base key, KID).
+    pub fn reset_to(&mut self, start_value: u64) {
+        self.current_counter = start_value;
+        self.exhausted = false;
+    }
 }
 
 impl FrameCounter for MonotonicCounter {
-    fn next(&mut self) -> Counter {
-        let counter = self.current_counter;
-        self.current_counter = self.current_counter.wrapping_add(1);
-
-        if self.current_counter > self.max_counter {
-            self.current_counter = 0;
+    fn next(&mut self) -> Option<Counter> {
+        if self.exhausted {
+            return None;
         }
 
-        counter
+        let counter = self.current_counter;
+
+        if counter == self.max_counter {
+            if self.allow_overrun {
+                self.current_counter = 0;
+            } else {
+                self.exhausted = true;
+            }
+        } else {
+            self.current_counter += 1;
+        }
+
+        Some(counter)
     }
 }
 
@@ -62,6 +118,8 @@ impl Default for MonotonicCounter {
         Self {
             current_counter: 0,
             max_counter: u64::MAX,
+            allow_overrun: false,
+            exhausted: false,
         }
     }
 }
@@ -78,27 +136,75 @@ mod test {
         let mut counter = MonotonicCounter::default();
 
         for i in 0..10 {
-            assert_eq!(counter.next(), i);
+            assert_eq!(counter.next(), Some(i));
         }
     }
+
     #[test]
-    fn wraps_after_u64_max_was_reached() {
+    fn exhausted_after_u64_max_was_reached() {
         let mut counter = MonotonicCounter::new(u64::MAX);
 
         counter.current_counter = u64::MAX - 1;
 
-        assert_eq!(counter.next(), u64::MAX - 1);
-        assert_eq!(counter.next(), u64::MAX);
-        assert_eq!(counter.next(), 0);
+        assert_eq!(counter.next(), Some(u64::MAX - 1));
+        assert_eq!(counter.next(), Some(u64::MAX));
+        assert_eq!(counter.next(), None);
+        assert!(counter.is_exhausted());
     }
 
     #[test]
-    fn wraps_after_max_counter_was_reached() {
+    fn exhausted_after_max_counter_was_reached() {
         let max_counter = 1;
         let mut counter = MonotonicCounter::new(max_counter);
 
-        assert_eq!(counter.next(), 0);
-        assert_eq!(counter.next(), 1);
-        assert_eq!(counter.next(), 0);
+        assert_eq!(counter.next(), Some(0));
+        assert_eq!(counter.next(), Some(1));
+        assert_eq!(counter.next(), None);
+        assert_eq!(counter.next(), None);
+    }
+
+    #[test]
+    fn does_not_reuse_counter_after_exhaustion_without_overrun() {
+        let max_counter = 0;
+        let mut counter = MonotonicCounter::new(max_counter);
+
+        assert_eq!(counter.next(), Some(0));
+        for _ in 0..3 {
+            assert_eq!(counter.next(), None);
+        }
+    }
+
+    #[test]
+    fn wraps_after_max_counter_was_reached_when_overrun_is_allowed() {
+        let max_counter = 1;
+        let mut counter = MonotonicCounter::new(max_counter).allow_overrun(true);
+
+        assert_eq!(counter.next(), Some(0));
+        assert_eq!(counter.next(), Some(1));
+        assert_eq!(counter.next(), Some(0));
+        assert_eq!(counter.next(), Some(1));
+    }
+
+    #[test]
+    fn reset_clears_exhausted_state() {
+        let mut counter = MonotonicCounter::new(0);
+
+        assert_eq!(counter.next(), Some(0));
+        assert_eq!(counter.next(), None);
+
+        counter.reset();
+        assert_eq!(counter.next(), Some(0));
+        assert_eq!(counter.next(), None);
+    }
+
+    #[test]
+    fn reset_to_starts_from_given_value() {
+        let mut counter = MonotonicCounter::new(10);
+
+        assert_eq!(counter.next(), Some(0));
+
+        counter.reset_to(5);
+        assert_eq!(counter.next(), Some(5));
+        assert_eq!(counter.next(), Some(6));
     }
 }

--- a/src/frame/media_frame.rs
+++ b/src/frame/media_frame.rs
@@ -4,7 +4,7 @@ use crate::{
         buffer::{AadData, encryption::EncryptionBuffer},
         key_derivation::KeyDerivation,
     },
-    error::Result,
+    error::{Result, SframeError},
     header::{Counter, SframeHeader},
     key::crypto_key::EncryptionKey,
 };
@@ -25,25 +25,29 @@ pub struct MediaFrameView<'buf> {
 
 impl<'ibuf> MediaFrameView<'ibuf> {
     /// Creates a new view on a payload buffer and assigns it the next counter (CTR)  value.
-    pub fn new<P>(frame_counter: &mut impl FrameCounter, payload: &'ibuf P) -> Self
+    /// Returns [`crate::error::SframeError::CounterExhausted`] if `frame_counter` has run out of
+    /// counter values for the current (base key, KID).
+    pub fn new<P>(frame_counter: &mut impl FrameCounter, payload: &'ibuf P) -> Result<Self>
     where
         P: AsRef<[u8]> + ?Sized,
     {
         Self::with_meta_data(frame_counter, payload, &[])
     }
 
-    /// Creates a new view on a payload buffer, assigns it the given frame count and associates it with the meta data
+    /// Creates a new view on a payload buffer, assigns it the given frame count and associates it with the meta data.
+    /// Returns [`crate::error::SframeError::CounterExhausted`] if `frame_counter` has run out of
+    /// counter values for the current (base key, KID).
     pub fn with_meta_data<P, M>(
         frame_counter: &mut impl FrameCounter,
         payload: &'ibuf P,
         meta_data: &'ibuf M,
-    ) -> Self
+    ) -> Result<Self>
     where
         P: AsRef<[u8]> + ?Sized,
         M: AsRef<[u8]> + ?Sized,
     {
-        let counter = frame_counter.next();
-        Self::with_meta_data_and_ctr(counter, payload, meta_data)
+        let counter = frame_counter.next().ok_or(SframeError::CounterExhausted)?;
+        Ok(Self::with_meta_data_and_ctr(counter, payload, meta_data))
     }
 
     pub(super) fn with_meta_data_and_ctr<P, M>(
@@ -173,7 +177,9 @@ pub struct MediaFrame {
 
 impl MediaFrame {
     /// Creates a new media frame by copying the data of a payload buffer and assigning it the given frame count.
-    pub fn new<P>(frame_counter: &mut impl FrameCounter, payload: P) -> Self
+    /// Returns [`crate::error::SframeError::CounterExhausted`] if `frame_counter` has run out of
+    /// counter values for the current (base key, KID).
+    pub fn new<P>(frame_counter: &mut impl FrameCounter, payload: P) -> Result<Self>
     where
         P: AsRef<[u8]>,
     {
@@ -182,17 +188,19 @@ impl MediaFrame {
 
     /// Creates a new media frame and assigns it the given frame count.
     /// Payload and meta data are copied into an internal buffer.
+    /// Returns [`crate::error::SframeError::CounterExhausted`] if `frame_counter` has run out of
+    /// counter values for the current (base key, KID).
     pub fn with_meta_data<P, M>(
         frame_counter: &mut impl FrameCounter,
         payload: P,
         meta_data: M,
-    ) -> Self
+    ) -> Result<Self>
     where
         P: AsRef<[u8]>,
         M: AsRef<[u8]>,
     {
-        let counter = frame_counter.next();
-        Self::with_meta_data_and_ctr(counter, payload, meta_data)
+        let counter = frame_counter.next().ok_or(SframeError::CounterExhausted)?;
+        Ok(Self::with_meta_data_and_ctr(counter, payload, meta_data))
     }
 
     pub(super) fn with_meta_data_and_ctr<P, M>(counter: Counter, payload: P, meta_data: M) -> Self

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -31,7 +31,7 @@
 //!
 //! let mut encrypt_buffer = Vec::new();
 //! let mut decrypt_buffer = Vec::new();
-//! let media_frame = MediaFrameView::new(&mut counter, payload);
+//! let media_frame = MediaFrameView::new(&mut counter, payload).unwrap();
 //!
 //! let encrypted_frame = media_frame.encrypt_into(&enc_key, &mut encrypt_buffer).unwrap();
 //!
@@ -88,7 +88,7 @@ mod test {
         let mut decrypt_buffer = Vec::new();
         let mut counter = MonotonicCounter::default();
 
-        let media_frame = MediaFrameView::new(&mut counter, PAYLOAD);
+        let media_frame = MediaFrameView::new(&mut counter, PAYLOAD).unwrap();
         media_frame
             .encrypt_into(&enc_key, &mut encrypt_buffer)
             .unwrap();
@@ -108,7 +108,7 @@ mod test {
         let mut decrypt_buffer = Vec::new();
         let mut counter = MonotonicCounter::default();
 
-        let media_frame = MediaFrameView::with_meta_data(&mut counter, PAYLOAD, META_DATA);
+        let media_frame = MediaFrameView::with_meta_data(&mut counter, PAYLOAD, META_DATA).unwrap();
         media_frame
             .encrypt_into(&enc_key, &mut encrypt_buffer)
             .unwrap();
@@ -129,7 +129,7 @@ mod test {
         let (enc_key, dec_key) = expand_keys();
         let mut counter = MonotonicCounter::default();
 
-        let media_frame = MediaFrame::with_meta_data(&mut counter, PAYLOAD, META_DATA);
+        let media_frame = MediaFrame::with_meta_data(&mut counter, PAYLOAD, META_DATA).unwrap();
         let encrypted = media_frame.encrypt(&enc_key).unwrap();
 
         assert_bytes_eq(encrypted.meta_data(), META_DATA);

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -64,6 +64,7 @@ mod test {
     use super::media_frame::MediaFrameView;
     use crate::{
         CipherSuite,
+        error::SframeError,
         frame::{MonotonicCounter, encrypted_frame::EncryptedFrameView, media_frame::MediaFrame},
         key::{DecryptionKey, EncryptionKey},
         util::test::assert_bytes_eq,
@@ -137,5 +138,22 @@ mod test {
         let decrypted_media_frame = encrypted.decrypt(&dec_key).unwrap();
 
         assert_eq!(decrypted_media_frame, media_frame);
+    }
+
+    #[test]
+    fn exhausted_counter_prevents_encryption_instead_of_reusing_a_counter() {
+        // An exhausted counter must never be silently reused for encryption, as that would
+        // break confidentiality by reusing (base key, KID, CTR).
+        let mut counter = MonotonicCounter::new(0);
+        assert!(MediaFrameView::new(&mut counter, PAYLOAD).is_ok());
+
+        assert_eq!(
+            MediaFrameView::new(&mut counter, PAYLOAD).unwrap_err(),
+            SframeError::CounterExhausted
+        );
+        assert_eq!(
+            MediaFrame::new(&mut counter, PAYLOAD).unwrap_err(),
+            SframeError::CounterExhausted
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #96.

`FrameCounter::next()` previously returned a plain `Counter`, so a caller had no way to know when the counter space for a `(base key, KID)` had been exhausted. The default `MonotonicCounter` implementation then silently wrapped back to `0`, which reuses `(base key, KID, CTR)` and breaks AEAD confidentiality (see [RFC 9605 9.1](https://www.rfc-editor.org/rfc/rfc9605.html#name-header-value-uniqueness)).

## Changes

- `FrameCounter::next()` now returns `Option<Counter>`, returning `None` once the counter space is exhausted.
- Added `SframeError::CounterExhausted`.
- `MediaFrameView::new`/`with_meta_data` and `MediaFrame::new`/`with_meta_data` now return `Result<Self>`, returning `SframeError::CounterExhausted` instead of encrypting with a reused counter.
- `MonotonicCounter` no longer wraps around by default once `max_counter` is reached; it becomes exhausted instead.
- Wrapping can still be opted into explicitly via `MonotonicCounter::allow_overrun(true)`, for callers that can independently guarantee the key/KID is rotated before the counter wraps.
- Added `MonotonicCounter::is_exhausted()`, `reset()` and `reset_to(start_value)` to explicitly restart a counter after rotating to a new `(base key, KID)`.
- Updated examples, benches, doctests and README accordingly.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo test --all-targets`
- [x] `cargo test --doc`
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt --check`
- [x] Added unit tests covering exhaustion, `allow_overrun`, `reset`, `reset_to`