### PR TITLE
fix: prevent replay-window poisoning by unauthenticated frames

### DIFF
--- a/examples/sender_receiver/receiver.rs
+++ b/examples/sender_receiver/receiver.rs
@@ -67,15 +67,20 @@ impl Receiver {
         let meta_data = &encrypted_frame[..skip];
         let encrypted_frame = EncryptedFrameView::try_with_meta_data(data, meta_data)?;
 
-        if let Some(validator) = &self.frame_validation {
-            encrypted_frame.validate(validator)?;
-        }
-
         if let ReceiverKeyStore::Ratcheting(keys) = &mut self.keys {
             keys.try_ratchet(encrypted_frame.header().key_id())?;
         }
 
-        encrypted_frame.decrypt_into(&self.keys, &mut self.buffer)?;
+        match &mut self.frame_validation {
+            Some(validator) => {
+                encrypted_frame
+                    .validate(validator)?
+                    .decrypt_into(&self.keys, &mut self.buffer)?;
+            }
+            None => {
+                encrypted_frame.decrypt_into(&self.keys, &mut self.buffer)?;
+            }
+        }
 
         Ok(&self.buffer)
     }

--- a/src/frame/encrypted_frame.rs
+++ b/src/frame/encrypted_frame.rs
@@ -90,17 +90,22 @@ impl<'ibuf> EncryptedFrameView<'ibuf> {
         self.cipher_text
     }
 
-    /// Validates the header of the encrypted frame
-    /// Semantic sugar to allow chaining the validation with decryption
-    /// returns an [`crate::error::SframeError`] when validation fails
-    pub fn validate<V>(self, validator: &V) -> Result<Self>
+    /// Runs the read-only pre-decrypt screen of `validator` against this frame's header and,
+    /// on success, returns a [`ValidatedFrameView`] wrapping the decrypt methods.
+    /// `validator` is only ever mutated - to record this frame's counter - if the returned
+    /// [`ValidatedFrameView`] is subsequently decrypted successfully, i.e. authenticated.
+    /// Returns an [`crate::error::SframeError`] when the screen rejects the header.
+    pub fn validate<'v, V>(self, validator: &'v mut V) -> Result<ValidatedFrameView<'ibuf, 'v, V>>
     where
         V: FrameValidation + ?Sized,
     {
         log::trace!("Validating EncryptedFrame # {}", self.header.counter());
-        validator.validate(&self.header)?;
+        validator.pre_decrypt(&self.header)?;
 
-        Ok(self)
+        Ok(ValidatedFrameView {
+            frame: self,
+            validator,
+        })
     }
 
     /// Tries to decrypt the encrypted frame with a key from the provided key store.
@@ -157,6 +162,51 @@ impl<'ibuf> EncryptedFrameView<'ibuf> {
         let (meta_data, payload) = buffer_slice.split_at(meta_len);
 
         let media_frame = MediaFrameView::with_meta_data_and_ctr(counter, payload, meta_data);
+        Ok(media_frame)
+    }
+}
+
+/// An [`EncryptedFrameView`] that has passed a [`FrameValidation`]'s pre-decrypt screen and
+/// borrows the validator that produced it. Decrypting it successfully is the only way to have
+/// the validator record the frame's counter, via [`FrameValidation::post_decrypt`] - so a
+/// counter can never be recorded before its frame has actually been authenticated.
+/// Obtained from [`EncryptedFrameView::validate`].
+pub struct ValidatedFrameView<'buf, 'v, V: FrameValidation + ?Sized> {
+    frame: EncryptedFrameView<'buf>,
+    validator: &'v mut V,
+}
+
+impl<'buf, V: FrameValidation + ?Sized> ValidatedFrameView<'buf, '_, V> {
+    /// the header of the wrapped encrypted frame
+    pub fn header(&self) -> &SframeHeader {
+        self.frame.header()
+    }
+
+    /// Tries to decrypt the wrapped frame, see [`EncryptedFrameView::decrypt`].
+    /// On success, the frame's counter is recorded with the validator this was obtained from.
+    pub fn decrypt<A, D>(self, key_store: &impl KeyStore<A, D>) -> Result<MediaFrame>
+    where
+        A: AeadDecrypt<Secret = D::Secret>,
+        D: KeyDerivation,
+    {
+        let media_frame = self.frame.decrypt(key_store)?;
+        self.validator.post_decrypt(self.frame.header());
+        Ok(media_frame)
+    }
+
+    /// Tries to decrypt the wrapped frame, see [`EncryptedFrameView::decrypt_into`].
+    /// On success, the frame's counter is recorded with the validator this was obtained from.
+    pub fn decrypt_into<'obuf, A, D>(
+        self,
+        key_store: &impl KeyStore<A, D>,
+        buffer: &'obuf mut impl FrameBuffer,
+    ) -> Result<MediaFrameView<'obuf>>
+    where
+        A: AeadDecrypt<Secret = D::Secret>,
+        D: KeyDerivation,
+    {
+        let media_frame = self.frame.decrypt_into(key_store, buffer)?;
+        self.validator.post_decrypt(self.frame.header());
         Ok(media_frame)
     }
 }
@@ -258,18 +308,22 @@ impl EncryptedFrame {
         &self.buffer[self.meta_len + self.header.len()..]
     }
 
-    /// Validates the header of the encrypted frame
-    /// Semantic sugar to allow chaining the validation with decryption
-    /// returns an [`crate::error::SframeError`] when validation fails
-    // TODO(v2): validator  should be mutable
-    pub fn validate<V>(self, validator: &V) -> Result<Self>
+    /// Runs the read-only pre-decrypt screen of `validator` against this frame's header and,
+    /// on success, returns a [`ValidatedFrame`] wrapping the decrypt methods.
+    /// `validator` is only ever mutated - to record this frame's counter - if the returned
+    /// [`ValidatedFrame`] is subsequently decrypted successfully, i.e. authenticated.
+    /// Returns an [`crate::error::SframeError`] when the screen rejects the header.
+    pub fn validate<V>(self, validator: &mut V) -> Result<ValidatedFrame<'_, V>>
     where
         V: FrameValidation + ?Sized,
     {
         log::trace!("Validating EncryptedFrame # {}", self.header.counter());
-        validator.validate(&self.header)?;
+        validator.pre_decrypt(&self.header)?;
 
-        Ok(self)
+        Ok(ValidatedFrame {
+            frame: self,
+            validator,
+        })
     }
 
     /// Tries to decrypt the encrypted frame with a key from the provided key store.
@@ -312,6 +366,51 @@ impl EncryptedFrame {
         );
 
         view.decrypt_into(key_store, buffer)
+    }
+}
+
+/// An [`EncryptedFrame`] that has passed a [`FrameValidation`]'s pre-decrypt screen and
+/// borrows the validator that produced it. Decrypting it successfully is the only way to have
+/// the validator record the frame's counter, via [`FrameValidation::post_decrypt`] - so a
+/// counter can never be recorded before its frame has actually been authenticated.
+/// Obtained from [`EncryptedFrame::validate`].
+pub struct ValidatedFrame<'v, V: FrameValidation + ?Sized> {
+    frame: EncryptedFrame,
+    validator: &'v mut V,
+}
+
+impl<V: FrameValidation + ?Sized> ValidatedFrame<'_, V> {
+    /// the header of the wrapped encrypted frame
+    pub fn header(&self) -> &SframeHeader {
+        self.frame.header()
+    }
+
+    /// Tries to decrypt the wrapped frame, see [`EncryptedFrame::decrypt`].
+    /// On success, the frame's counter is recorded with the validator this was obtained from.
+    pub fn decrypt<A, D>(self, key_store: &impl KeyStore<A, D>) -> Result<MediaFrame>
+    where
+        A: AeadDecrypt<Secret = D::Secret>,
+        D: KeyDerivation,
+    {
+        let media_frame = self.frame.decrypt(key_store)?;
+        self.validator.post_decrypt(self.frame.header());
+        Ok(media_frame)
+    }
+
+    /// Tries to decrypt the wrapped frame, see [`EncryptedFrame::decrypt_into`].
+    /// On success, the frame's counter is recorded with the validator this was obtained from.
+    pub fn decrypt_into<'obuf, A, D>(
+        self,
+        key_store: &impl KeyStore<A, D>,
+        buffer: &'obuf mut impl FrameBuffer,
+    ) -> Result<MediaFrameView<'obuf>>
+    where
+        A: AeadDecrypt<Secret = D::Secret>,
+        D: KeyDerivation,
+    {
+        let media_frame = self.frame.decrypt_into(key_store, buffer)?;
+        self.validator.post_decrypt(self.frame.header());
+        Ok(media_frame)
     }
 }
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -53,7 +53,7 @@ mod frame_counter;
 mod media_frame;
 mod validation;
 
-pub use encrypted_frame::{EncryptedFrame, EncryptedFrameView};
+pub use encrypted_frame::{EncryptedFrame, EncryptedFrameView, ValidatedFrame, ValidatedFrameView};
 pub use frame_buffer::{FrameBuffer, Truncate};
 pub use frame_counter::*;
 pub use media_frame::{MediaFrame, MediaFrameView};

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -64,7 +64,11 @@ mod test {
     use super::media_frame::MediaFrameView;
     use crate::{
         CipherSuite,
-        frame::{MonotonicCounter, encrypted_frame::EncryptedFrameView, media_frame::MediaFrame},
+        error::SframeError,
+        frame::{
+            MonotonicCounter, ReplayAttackProtection, encrypted_frame::EncryptedFrameView,
+            media_frame::MediaFrame,
+        },
         key::{DecryptionKey, EncryptionKey},
         util::test::assert_bytes_eq,
     };
@@ -137,5 +141,44 @@ mod test {
         let decrypted_media_frame = encrypted.decrypt(&dec_key).unwrap();
 
         assert_eq!(decrypted_media_frame, media_frame);
+    }
+
+    #[test]
+    fn forged_frame_that_fails_authentication_does_not_poison_the_replay_window() {
+        let (enc_key, dec_key) = expand_keys();
+        let mut counter = MonotonicCounter::default();
+        let mut encrypt_buffer = Vec::new();
+        let mut decrypt_buffer = Vec::new();
+
+        let media_frame = MediaFrameView::new(&mut counter, PAYLOAD);
+        media_frame
+            .encrypt_into(&enc_key, &mut encrypt_buffer)
+            .unwrap();
+
+        // Flip the last byte (part of the auth tag) so the frame carries a valid, replayable
+        // counter but fails authentication - simulating a forged frame.
+        let last = encrypt_buffer.len() - 1;
+        encrypt_buffer[last] ^= 0xFF;
+
+        let mut validator = ReplayAttackProtection::with_tolerance(4);
+
+        let forged_frame = EncryptedFrameView::try_new(&encrypt_buffer).unwrap();
+        let err = forged_frame
+            .validate(&mut validator)
+            .unwrap()
+            .decrypt_into(&dec_key, &mut decrypt_buffer)
+            .unwrap_err();
+        assert_eq!(err, SframeError::DecryptionFailure);
+
+        // Restore the original ciphertext - the legitimate frame carrying the very same
+        // counter - and make sure it is still accepted. Had the forged frame's counter been
+        // recorded despite failing authentication, this would be rejected as a duplicate.
+        encrypt_buffer[last] ^= 0xFF;
+        let legitimate_frame = EncryptedFrameView::try_new(&encrypt_buffer).unwrap();
+        legitimate_frame
+            .validate(&mut validator)
+            .unwrap()
+            .decrypt_into(&dec_key, &mut decrypt_buffer)
+            .unwrap();
     }
 }

--- a/src/frame/validation/mod.rs
+++ b/src/frame/validation/mod.rs
@@ -1,24 +1,36 @@
 use crate::{error::Result, header::SframeHeader};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 mod replay_attack_protection;
 mod sliding_window;
 
 pub use replay_attack_protection::ReplayAttackProtection;
 
-/// Allows to validate frames by their sframe header before the decryption
+/// Allows to validate frames by their sframe header, split into two steps around decryption
+/// so that state which influences subsequent frames (e.g. a replay window) can only ever be
+/// mutated *after* a frame has been authenticated.
 pub trait FrameValidation {
-    /// checks if the new header is valid, returns an [`SframeError`] if not
-    // TODO(v2): validator (self) should be mutable
-    fn validate(&self, header: &SframeHeader) -> Result<()>;
+    /// Read-only screen run **before** decryption, checked against the state committed by
+    /// previous, successfully authenticated frames. Must not mutate any state that influences
+    /// the validation of subsequent frames. Returns an [`SframeError`] if the header is
+    /// rejected, e.g. because it is a replay.
+    fn pre_decrypt(&self, header: &SframeHeader) -> Result<()>;
+
+    /// Records the header. Only ever called **after** the frame carrying it has been
+    /// successfully decrypted, i.e. authenticated. This is the only place validation state
+    /// may be mutated.
+    fn post_decrypt(&mut self, header: &SframeHeader);
 }
 
 /// Box to any implementation of the `FrameValidation` trait
 pub type FrameValidationBox = Box<dyn FrameValidation>;
 
-// TODO(v2): validator (self) should be mutable
 impl FrameValidation for FrameValidationBox {
-    fn validate(&self, header: &SframeHeader) -> Result<()> {
-        self.deref().validate(header)
+    fn pre_decrypt(&self, header: &SframeHeader) -> Result<()> {
+        self.deref().pre_decrypt(header)
+    }
+
+    fn post_decrypt(&mut self, header: &SframeHeader) {
+        self.deref_mut().post_decrypt(header);
     }
 }

--- a/src/frame/validation/replay_attack_protection.rs
+++ b/src/frame/validation/replay_attack_protection.rs
@@ -3,13 +3,18 @@ use crate::{
     frame::{FrameValidation, validation::sliding_window::SlidingWindow},
     header::{self, SframeHeader},
 };
-use std::cell::RefCell;
 
 /// This implementation allows to detect replay attacks by omitting frames with
 /// to old frame counters, see [RFC 9605 9.3](https://www.rfc-editor.org/rfc/rfc9605.html#name-anti-replay).
 /// The window of allowed frame counts is given with a certain tolerance.
+///
+/// Following [`FrameValidation`], recording a counter into the window only ever happens in
+/// [`FrameValidation::post_decrypt`], i.e. after the frame carrying it has been authenticated.
+/// [`FrameValidation::pre_decrypt`] only ever performs a read-only screen against the state
+/// committed by previously authenticated frames, so a forged frame can never poison the window
+/// and cause a later, legitimate frame to be rejected as a duplicate.
 pub struct ReplayAttackProtection {
-    window: RefCell<Window>,
+    window: Window,
 }
 
 impl ReplayAttackProtection {
@@ -24,32 +29,38 @@ impl ReplayAttackProtection {
             .try_into()
             .expect("Tolerance exceeds OS capabilities");
         ReplayAttackProtection {
-            window: RefCell::new(Window::Empty(Empty {
+            window: Window::Empty(Empty {
                 window: SlidingWindow::new(size),
                 size: size as u64,
-            })),
+            }),
         }
     }
 }
 
 impl FrameValidation for ReplayAttackProtection {
-    fn validate(&self, header: &SframeHeader) -> Result<()> {
-        let counter = header.counter();
-        let mut window = self.window.borrow_mut();
+    fn pre_decrypt(&self, header: &SframeHeader) -> Result<()> {
+        match &self.window {
+            // Nothing has been committed yet, any frame counter is a valid anchor.
+            Window::Empty(_) => Ok(()),
+            Window::Active(active) => active.screen(header.counter()),
+        }
+    }
 
-        match &mut *window {
-            Window::Active(active) => active.check(counter),
+    fn post_decrypt(&mut self, header: &SframeHeader) {
+        let counter = header.counter();
+
+        match &mut self.window {
+            Window::Active(active) => active.commit(counter),
             Window::Empty(empty) => {
-                // First frame: swap the pre-allocated `Empty` out (the placeholder
-                // holds an empty, non-allocating window) and consume it to anchor.
+                // First authenticated frame: swap the pre-allocated `Empty` out (the
+                // placeholder holds an empty, non-allocating window) and consume it to anchor.
                 let placeholder = Empty {
                     window: SlidingWindow::new(0),
                     size: 0,
                 };
                 let mut active = std::mem::replace(empty, placeholder).anchor(counter);
-                let result = active.check(counter);
-                *window = Window::Active(active);
-                result
+                active.commit(counter);
+                self.window = Window::Active(active);
             }
         }
     }
@@ -87,23 +98,38 @@ struct Active {
 }
 
 impl Active {
-    fn check(&mut self, counter: header::Counter) -> Result<()> {
-        if self.is_newer(counter) {
-            self.advance_to(counter);
-        }
-
+    /// Read-only screen against the currently committed window: does not advance the window
+    /// and does not mark `counter` as seen, so it is safe to call before authentication.
+    fn screen(&self, counter: header::Counter) -> Result<()> {
         let err = |reason| {
             Err(SframeError::FrameValidationFailed(format!(
                 "Replay check failed, frame counter {counter} {reason}"
             )))
         };
+
+        // A counter beyond the currently committed window has, by definition, never been
+        // recorded - accept it here without touching the window; `commit` will advance the
+        // window to it once the frame has actually been authenticated.
+        if self.is_newer(counter) {
+            return Ok(());
+        }
+
         match self.window_index(counter) {
             None => err(REJECT_TOO_OLD),
             Some(idx) if self.window.is_set(idx) => err(REJECT_DUPLICATED),
-            Some(idx) => {
-                self.window.set(idx);
-                Ok(())
-            }
+            Some(_) => Ok(()),
+        }
+    }
+
+    /// The only mutation: advances the window if `counter` is newer than the current newest,
+    /// then marks it as seen. Must only be called for an authenticated `counter`.
+    fn commit(&mut self, counter: header::Counter) {
+        if self.is_newer(counter) {
+            self.advance_to(counter);
+        }
+
+        if let Some(idx) = self.window_index(counter) {
+            self.window.set(idx);
         }
     }
 
@@ -170,23 +196,40 @@ mod test {
     struct Fixture(ReplayAttackProtection);
 
     impl Fixture {
-        fn expect_accepted(&self, counter: header::Counter) -> &Self {
+        /// Simulates a full validate -> decrypt -> commit round trip for an authenticated
+        /// frame: `pre_decrypt` must accept it, and only then is it committed via
+        /// `post_decrypt`, mirroring [`ValidatedFrameView::decrypt`]/[`ValidatedFrame::decrypt`].
+        fn expect_accepted(&mut self, counter: header::Counter) -> &mut Self {
             assert_eq!(
-                self.0.validate(&header(counter)),
+                self.0.pre_decrypt(&header(counter)),
                 Ok(()),
                 "counter {counter} should be accepted"
             );
+            self.0.post_decrypt(&header(counter));
             self
         }
 
-        fn expect_rejected(&self, counter: header::Counter, reason: &str) -> &Self {
-            match self.0.validate(&header(counter)) {
+        /// Simulates a frame rejected by the pre-decrypt screen, which never reaches
+        /// decryption and therefore never commits.
+        fn expect_rejected(&mut self, counter: header::Counter, reason: &str) -> &mut Self {
+            match self.0.pre_decrypt(&header(counter)) {
                 Err(SframeError::FrameValidationFailed(msg)) => assert!(
                     msg.contains(reason),
                     "counter {counter}: expected reason {reason:?}, got: {msg}"
                 ),
                 other => panic!("counter {counter}: expected rejection {reason:?}, got: {other:?}"),
             }
+            self
+        }
+
+        /// Simulates a frame whose header passes the pre-decrypt screen but which then fails
+        /// to authenticate (e.g. a forged frame) - `post_decrypt` must never be called for it.
+        fn expect_screened_but_not_committed(&mut self, counter: header::Counter) -> &mut Self {
+            assert_eq!(
+                self.0.pre_decrypt(&header(counter)),
+                Ok(()),
+                "counter {counter} should pass the pre-decrypt screen"
+            );
             self
         }
     }
@@ -267,7 +310,7 @@ mod test {
 
     #[test]
     fn jump_beyond_window_clears_all_marks() {
-        let validator = validator();
+        let mut validator = validator();
         validator.expect_accepted(NEWEST);
         for counter in WINDOW_OLDEST..NEWEST {
             validator.expect_accepted(counter);
@@ -285,12 +328,37 @@ mod test {
     #[test]
     fn handle_overflowing_counters() {
         let start = header::Counter::MAX - 3;
-        let validator = validator();
+        let mut validator = validator();
         validator.expect_accepted(start);
 
         for step in 1..10 {
             // wrapping_add dodges the debug overflow panic as we cross u64::MAX
             validator.expect_accepted(start.wrapping_add(step));
         }
+    }
+
+    #[test]
+    fn screening_an_unauthenticated_header_does_not_poison_the_window_for_a_legitimate_frame() {
+        // Regression test: a frame that only passes the pre-decrypt screen (e.g. because it
+        // never authenticates) must not be able to suppress a later, legitimate frame that
+        // carries the same counter.
+        let mut validator = validator();
+
+        validator.expect_screened_but_not_committed(NEWEST);
+        // The counter was never committed, so the legitimate frame carrying it is still
+        // accepted, not rejected as a duplicate.
+        validator.expect_accepted(NEWEST);
+    }
+
+    #[test]
+    fn screening_does_not_anchor_the_window_before_the_first_frame_is_authenticated() {
+        // Regression test: on an empty window, pre_decrypt must not anchor the window by
+        // itself - only a committed (authenticated) frame may do so.
+        let mut validator = validator();
+
+        validator.expect_screened_but_not_committed(NEWEST);
+        // Had `pre_decrypt` anchored the window at `NEWEST`, `TOO_OLD` would now be rejected
+        // as too old even though no frame has actually been authenticated yet.
+        validator.expect_accepted(TOO_OLD);
     }
 }


### PR DESCRIPTION
## Summary

Closes #95.

`FrameValidation::validate()` ran entirely before decryption, and `ReplayAttackProtection` marked a frame's counter as seen based solely on the **unauthenticated** header. A forged frame that never authenticates could still poison the replay window, so a later, legitimate frame carrying that same counter would then be rejected as a duplicate - a frame-suppression / self-inflicted-DoS vector requiring no break of the AEAD.

This implements the two-conceptual-actions direction from the issue (screen vs. commit), following the API sketch left in the issue comments: a typestate wrapper that ties the commit to a successful decrypt.

## Changes

- `FrameValidation` is split into two steps:
  - `pre_decrypt(&self, header) -> Result<()>`: a **read-only** screen against previously committed state, run before decryption. Never mutates.
  - `post_decrypt(&mut self, header)`: the only place validation state may be mutated. Only ever called after the frame has been **successfully decrypted**.
- `EncryptedFrameView::validate`/`EncryptedFrame::validate` now take `&mut validator`, run the pre-decrypt screen, and return a new `ValidatedFrameView`/`ValidatedFrame` that borrows the validator.
- `ValidatedFrameView::decrypt`/`decrypt_into` (and the `ValidatedFrame` equivalents) call `post_decrypt()` **only** on a successful decrypt - so a counter can never be recorded before its frame has actually been authenticated, and there's no separate "commit" call a caller could forget.
- Callers that don't call `.validate()` at all keep exactly today's decrypt path - no added ceremony for the no-replay-checking case.
- `ReplayAttackProtection` no longer anchors its window or marks a counter during the pre-decrypt screen; both are deferred to `post_decrypt`. This also removes the need for `RefCell` interior mutability, since `post_decrypt` already takes `&mut self`.
- Added regression tests demonstrating that screening (without a following commit) neither poisons the window for a later legitimate frame with the same counter, nor prematurely anchors an empty window.

## Out of scope

The issue's "additional observations" also flag that `ReplayAttackProtection` doesn't key state per KID (conflating counters from all senders in a multi-sender session). Left out of this PR to keep the fix focused and reviewable; happy to follow up separately if wanted.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo test --all-targets` (all existing replay-protection tests pass unmodified in behavior, only adapted to the two-phase API)
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt --check`
- [x] Added regression tests for the poisoning scenario and for premature window anchoring
- [x] `cargo run --example sender_receiver` (exercises `.validate()` end to end)