### PR TITLE
fix: handle frames shorter than the auth tag

### DIFF
--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -36,6 +36,7 @@ mod test {
             buffer::{DecryptionBufferView, EncryptionBufferView, encryption::EncryptionBuffer},
             cipher_suite::CipherSuite,
         },
+        error::SframeError,
         header::{KeyId, SframeHeader},
         key::{DecryptionKey, EncryptionKey},
         test_vectors::get_sframe_test_vector,
@@ -132,5 +133,28 @@ mod test {
         data.truncate(data.len() - dec_key.cipher_suite().auth_tag_len());
 
         assert_bytes_eq(&data, &test_vec.plain_text);
+    }
+
+    #[test_case(CipherSuite::AesGcm128Sha256; "AesGcm128Sha256")]
+    #[test_case(CipherSuite::AesGcm256Sha512; "AesGcm256Sha512")]
+    #[cfg_attr(aes_ctr, test_case(CipherSuite::AesCtr128HmacSha256_80; "AesCtr128HmacSha256_80"))]
+    #[cfg_attr(aes_ctr, test_case(CipherSuite::AesCtr128HmacSha256_64; "AesCtr128HmacSha256_64"))]
+    #[cfg_attr(aes_ctr, test_case(CipherSuite::AesCtr128HmacSha256_32; "AesCtr128HmacSha256_32"))]
+    fn decrypt_cipher_text_shorter_than_the_auth_tag(cipher_suite: CipherSuite) {
+        let dec_key =
+            DecryptionKey::derive_from(cipher_suite, KeyId::default(), KEY_MATERIAL.as_bytes())
+                .unwrap();
+        let header = SframeHeader::new(0, 0);
+        let mut aad = Vec::from(&header);
+        let mut data = vec![0u8; cipher_suite.auth_tag_len() - 1];
+
+        let decryption_buffer = DecryptionBufferView {
+            aad: &mut aad,
+            data: &mut data,
+        };
+
+        let result = dec_key.decrypt(decryption_buffer, header.counter());
+
+        assert_eq!(result.unwrap_err(), SframeError::DecryptionFailure);
     }
 }

--- a/src/crypto/buffer/decryption.rs
+++ b/src/crypto/buffer/decryption.rs
@@ -42,7 +42,10 @@ where
     }
     pub fn truncate(&mut self, cipher_suite: CipherSuite, dest: usize) {
         let decrypted_begin = self.aad_len;
-        let decrypted_len = self.cipher_text_len - cipher_suite.auth_tag_len();
+        // a cipher text shorter than the auth tag holds no plaintext at all
+        let decrypted_len = self
+            .cipher_text_len
+            .saturating_sub(cipher_suite.auth_tag_len());
         let decrypted_end = decrypted_begin + decrypted_len;
 
         self.io_buffer
@@ -116,6 +119,19 @@ mod test {
             DecryptionBuffer::try_allocate(&mut buf, &AAD_DATA, &encrypted_data).unwrap();
 
         dec_buf.truncate(CipherSuite::AesGcm128Sha256, 2);
+        assert_eq!(buf, AAD_DATA.data[0..2]);
+    }
+
+    #[test]
+    fn truncate_decryption_buffer_shorter_than_the_auth_tag() {
+        let mut buf = vec![];
+        let cipher_suite = CipherSuite::AesGcm128Sha256;
+        let encrypted_data = vec![7u8; cipher_suite.auth_tag_len() - 1];
+        let mut dec_buf =
+            DecryptionBuffer::try_allocate(&mut buf, &AAD_DATA, &encrypted_data).unwrap();
+
+        dec_buf.truncate(cipher_suite, 2);
+
         assert_eq!(buf, AAD_DATA.data[0..2]);
     }
 }


### PR DESCRIPTION
Fixes #103.

A cipher text shorter than the cipher suite's auth tag drove an underflowing subtraction in `DecryptionBuffer::truncate` — a panic in debug, a wrapped length in release. It now saturates, so a permissive AEAD backend (a custom `AeadDecrypt`, e.g. the `caesar_cipher` example) can no longer push the buffer arithmetic out of bounds.

Added Tests:
- `decrypt_cipher_text_shorter_than_the_auth_tag` — per backend, per cipher suite. The pre-existing frame level test used a permissive stub backend, so no real backend was covered.
- `truncate_decryption_buffer_shorter_than_the_auth_tag` — panicked before the `saturating_sub`.

