### PR TITLE
fix: ratchet the base key by every missed step

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,8 @@ pub enum SframeError {
     #[error("Unable to create unbound encryption key")]
     KeyDerivationFailure,
 
-    /// Could not ratchet an decryption key with HKDF
-    #[error("Unable to create unbound encryption key")]
+    /// Could not ratchet an decryption key with HKDF, or too many ratchet steps were requested
+    #[error("Unable to ratchet the decryption key")]
     RatchetingFailure,
 
     /// The cipher suite is not supported by the current crypto backend

--- a/src/ratchet/ratcheting_base_key.rs
+++ b/src/ratchet/ratcheting_base_key.rs
@@ -1,5 +1,7 @@
 use std::{marker::PhantomData, mem::replace};
 
+use zeroize::ZeroizeOnDrop;
+
 use crate::{CipherSuite, crypto::key_derivation::Ratcheting, error::Result};
 
 use super::ratcheting_key_id::RatchetingKeyId;
@@ -12,13 +14,17 @@ use super::ratcheting_key_id::RatchetingKeyId;
 /// The original key material is not stored for security reasons.
 ///
 /// Generic over the [`Ratcheting`] implementation `D` of the crypto backend.
+#[derive(ZeroizeOnDrop)]
 pub struct RatchetingBaseKey<D>
 where
     D: Ratcheting,
 {
+    #[zeroize(skip)]
     cipher_suite: CipherSuite,
     current_material: Vec<u8>,
+    #[zeroize(skip)]
     key_id: RatchetingKeyId,
+    #[zeroize(skip)]
     _ratcheting: PhantomData<D>,
 }
 
@@ -51,7 +57,7 @@ where
     }
 
     /// ratchets forward and provides a matching [`RatchetingKeyId`] and
-    /// a new base key to be used for key expansion in the sending block (e.g. [`crate::sender::Sender`] )
+    /// a new base key to be used for key expansion in the sending block
     pub fn next_base_key(&mut self) -> Result<(RatchetingKeyId, Vec<u8>)> {
         let key_id = self.key_id;
         let key_material = self.ratchet()?;

--- a/src/ratchet/ratcheting_key_id.rs
+++ b/src/ratchet/ratcheting_key_id.rs
@@ -60,6 +60,8 @@ impl RatchetingKeyId {
     where
         K: Into<KeyId>,
     {
+        let n_ratchet_bits = limit_bit_len("n_ratchet_bits", n_ratchet_bits, u64::BITS as u8 - 1);
+
         Self {
             value: key_id.into(),
             n_ratchet_bits,
@@ -79,7 +81,10 @@ impl RatchetingKeyId {
     /// increments the internal Ratchet Step by 1.
     /// If it reaches its maximum (2^R), it is set to 0
     pub fn inc_ratchet_step(&mut self) {
-        let ratchet_bitmask = u64::MAX >> (u64::BITS - self.n_ratchet_bits as u32);
+        // without ratcheting bits there is nothing to increment
+        let ratchet_bitmask = u64::MAX
+            .checked_shr(u64::BITS - self.n_ratchet_bits as u32)
+            .unwrap_or(0);
         // if all ratchet bits are set we have to wrap
         if self.value & ratchet_bitmask == ratchet_bitmask {
             // clear n_ratchet_bits
@@ -177,6 +182,30 @@ mod test {
 
         key_id.inc_ratchet_step();
         assert_eq!(1, key_id.ratchet_step());
+    }
+
+    #[test]
+    fn limits_n_ratchet_bits_to_63_on_parsing() {
+        let n_ratcheting_bits = 255;
+        let mut key_id = RatchetingKeyId::from_key_id(u64::MAX, n_ratcheting_bits);
+
+        // just one bit left for the generation
+        assert_eq!(1, key_id.generation());
+        assert_eq!(u64::MAX >> 1, key_id.ratchet_step());
+
+        key_id.inc_ratchet_step();
+        assert_eq!(0, key_id.ratchet_step());
+    }
+
+    #[test]
+    fn does_not_ratchet_without_ratcheting_bits() {
+        let expected_generation = 42;
+        let mut key_id = RatchetingKeyId::new(expected_generation, 0);
+
+        key_id.inc_ratchet_step();
+
+        assert_eq!(0, key_id.ratchet_step());
+        assert_eq!(expected_generation, key_id.generation());
     }
 
     #[test]

--- a/src/ratchet/ratcheting_key_store.rs
+++ b/src/ratchet/ratcheting_key_store.rs
@@ -9,6 +9,7 @@ use crate::{
     error::{Result, SframeError},
     header::KeyId,
     key::{KeyStore, crypto_key::DecryptionKey},
+    util::limit_bit_len,
 };
 
 use super::{ratcheting_base_key::RatchetingBaseKey, ratcheting_key_id::RatchetingKeyId};
@@ -17,6 +18,11 @@ use super::{ratcheting_base_key::RatchetingBaseKey, ratcheting_key_id::Ratchetin
 /// Allows to automatically ratchet forward an encryption key if necessary.
 ///
 /// Generic over the crypto backend used for decryption (`A`) and key derivation (`D`).
+///
+/// As the Ratchet Step is taken from an unauthenticated header, catching up with it lets an
+/// attacker trigger key derivations with a single forged frame. By default this is only bounded by
+/// the Ratchet Step itself (`2^n_ratchet_bits - 1` steps); pick a bound matching the expected loss
+/// and re-ordering with [`RatchetingKeyStore::with_max_ratchet_steps`].
 pub struct RatchetingKeyStore<A, D>
 where
     A: AeadDecrypt<Secret = D::Secret>,
@@ -24,6 +30,7 @@ where
 {
     keys: HashMap<RatchetingKeyId, RatchetingKeys<A, D>>,
     n_ratchet_bits: u8,
+    max_ratchet_steps: u64,
 }
 
 impl<A, D> RatchetingKeyStore<A, D>
@@ -31,12 +38,23 @@ where
     A: AeadDecrypt<Secret = D::Secret>,
     D: KeyDerivation + Ratcheting,
 {
-    /// creates a new [`RatchetingKeyStore`] which uses `n_ratchet_bits` to determine the Ratchet Step  
+    /// creates a new [`RatchetingKeyStore`] which uses `n_ratchet_bits` to determine the Ratchet
+    /// Step, limited to 63 bits as in [`RatchetingKeyId`]
     pub fn new(n_ratchet_bits: u8) -> Self {
+        let n_ratchet_bits = limit_bit_len("n_ratchet_bits", n_ratchet_bits, u64::BITS as u8 - 1);
+
         Self {
             n_ratchet_bits,
             keys: Default::default(),
+            max_ratchet_steps: (1u64 << n_ratchet_bits) - 1,
         }
+    }
+
+    /// limits how many ratchet steps [`RatchetingKeyStore::try_ratchet`] catches up with at once
+    // TODO(v2): make this an mandatory parameter?
+    pub fn with_max_ratchet_steps(mut self, max_ratchet_steps: u64) -> Self {
+        self.max_ratchet_steps = max_ratchet_steps;
+        self
     }
 
     /// returns the No. bits used to determine the Ratchet Step
@@ -95,6 +113,7 @@ where
     /// If the [`RatchetingKeyId`] indicates a Ratchet Step, which is different from the currently known one
     /// the [`RatchetingBaseKey`] is ratcheted forward accordingly.
     /// On success returns the number of ratcheting steps performed.
+    /// Fails if more than [`RatchetingKeyStore::with_max_ratchet_steps`] steps would be needed.
     // TODO(v2): This method mustn't commit, a forged header could evict a valid key else wise. A
     // two step API is needed
     // TODO(v2): improve the API, so it is easier to determine which was the KID ratched from
@@ -120,11 +139,16 @@ where
             .0)
             % max_ratchet_value;
 
-        let next_base_key = (0..step_diff)
-            .map(|_| keys.base_key.next_base_key())
-            .next_back();
-        if let Some(next_base_key) = next_base_key {
-            let (next_key_id, next_material) = next_base_key?;
+        if step_diff > self.max_ratchet_steps {
+            return Err(SframeError::RatchetingFailure);
+        }
+
+        let mut next_base_key = None;
+        for _ in 0..step_diff {
+            next_base_key = Some(keys.base_key.next_base_key()?);
+        }
+
+        if let Some((next_key_id, next_material)) = next_base_key {
             keys.dec_key = DecryptionKey::derive_from(
                 keys.dec_key.cipher_suite(),
                 next_key_id,
@@ -303,6 +327,69 @@ mod test {
         let second_secret = key_store.get_key(key_id).unwrap().clone();
 
         assert_eq!(first_secret, second_secret);
+    }
+
+    #[test]
+    fn ratchets_forward_multiple_steps_at_once() {
+        const STEPS: u64 = 3;
+        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
+        let mut step_by_step_store = RatchetingKeyStore::new(N_RATCHET_BITS);
+        let mut key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
+
+        key_store
+            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
+            .unwrap();
+        step_by_step_store
+            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
+            .unwrap();
+
+        for _ in 0..STEPS {
+            key_id.inc_ratchet_step();
+            step_by_step_store.try_ratchet(key_id).unwrap();
+        }
+
+        let ratchet_steps = key_store.try_ratchet(key_id).unwrap();
+
+        assert_eq!(ratchet_steps, STEPS);
+        let key = key_store.get_key(key_id).unwrap();
+        assert_eq!(
+            RatchetingKeyId::from_key_id(key.key_id(), N_RATCHET_BITS).ratchet_step(),
+            STEPS
+        );
+        assert_eq!(key, step_by_step_store.get_key(key_id).unwrap());
+    }
+
+    #[test]
+    fn rejects_ratcheting_beyond_the_maximum() {
+        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS).with_max_ratchet_steps(2);
+        let mut key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
+
+        key_store
+            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
+            .unwrap();
+        let key_before = key_store.get_key(key_id).unwrap().clone();
+
+        for _ in 0..3 {
+            key_id.inc_ratchet_step();
+        }
+
+        assert!(key_store.try_ratchet(key_id).is_err());
+        // the stored key must be untouched
+        assert_eq!(&key_before, key_store.get_key(key_id).unwrap());
+    }
+
+    #[test]
+    fn limits_n_ratchet_bits_to_63() {
+        let n_ratchet_bits = 255;
+        let mut key_store = RatchetingKeyStore::new(n_ratchet_bits);
+        let mut key_id = RatchetingKeyId::new(1u8, n_ratchet_bits);
+
+        key_store
+            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
+            .unwrap();
+        key_id.inc_ratchet_step();
+
+        assert!(key_store.try_ratchet(key_id).is_ok());
     }
 
     #[test]

--- a/src/ratchet/ratcheting_key_store.rs
+++ b/src/ratchet/ratcheting_key_store.rs
@@ -203,15 +203,28 @@ mod test {
     const N_RATCHET_BITS: u8 = 8;
     const KEY_MATERIAL: &[u8] = b"SECRET";
     const GENERATION: u64 = 42;
+    const CIPHER_SUITE: CipherSuite = CipherSuite::AesGcm256Sha512;
+
+    fn key_store_with_key() -> (RatchetingKeyStore, RatchetingKeyId) {
+        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
+        let key_id = insert_key(&mut key_store, N_RATCHET_BITS);
+
+        (key_store, key_id)
+    }
+
+    fn insert_key(key_store: &mut RatchetingKeyStore, n_ratchet_bits: u8) -> RatchetingKeyId {
+        let key_id = RatchetingKeyId::new(GENERATION, n_ratchet_bits);
+        key_store
+            .insert(CIPHER_SUITE, key_id, KEY_MATERIAL)
+            .unwrap();
+
+        key_id
+    }
 
     #[test]
     fn expands_and_ratchets_forward_on_insert() {
-        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-        let key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
+        let (key_store, key_id) = key_store_with_key();
 
-        key_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
         let keys = key_store.get(key_id);
 
         assert!(keys.is_some());
@@ -241,12 +254,8 @@ mod test {
 
     #[test]
     fn removes_key() {
-        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-        let key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
+        let (mut key_store, key_id) = key_store_with_key();
 
-        key_store
-            .insert(CipherSuite::AesGcm128Sha256, key_id, KEY_MATERIAL)
-            .unwrap();
         let was_removed = key_store.remove(key_id);
         let keys = key_store.get(key_id);
 
@@ -266,12 +275,8 @@ mod test {
 
     #[test]
     fn inserts_and_gets_key() {
-        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-        let key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
+        let (key_store, key_id) = key_store_with_key();
 
-        key_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
         let dec_key = key_store.get_key(key_id).unwrap();
 
         assert_eq!(KeyId::from(key_id), dec_key.key_id());
@@ -279,20 +284,13 @@ mod test {
 
     #[test]
     fn inserts_key_and_ratches_forward_if_needed() {
-        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-        let mut key_id = RatchetingKeyId::new(42u8, N_RATCHET_BITS);
-
-        key_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
+        let (mut key_store, mut key_id) = key_store_with_key();
 
         let ratchet_steps = key_store.try_ratchet(key_id).unwrap();
         assert_eq!(ratchet_steps, 0);
 
         let first_key = key_store.get_key(key_id).unwrap().clone();
-        let first_key_id = RatchetingKeyId::from_key_id(first_key.key_id(), N_RATCHET_BITS);
-        assert_eq!(first_key_id, key_id);
-        assert_eq!(first_key_id.ratchet_step(), 0);
+        assert_eq!(first_key.key_id(), KeyId::from(key_id));
 
         // ratchet
         key_id.inc_ratchet_step();
@@ -302,21 +300,12 @@ mod test {
 
         let second_key = key_store.get_key(key_id).unwrap();
         assert_ne!(first_key.secret(), second_key.secret());
-
-        let second_key_id = RatchetingKeyId::from_key_id(second_key.key_id(), N_RATCHET_BITS);
-        assert_eq!(second_key_id.ratchet_step(), 1);
-        assert_eq!(first_key_id, second_key_id);
+        assert_eq!(second_key.key_id(), KeyId::from(key_id));
     }
 
     #[test]
     fn stores_ratcheted_key() {
-        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-
-        let mut key_id = RatchetingKeyId::new(42u8, N_RATCHET_BITS);
-
-        key_store
-            .insert(CipherSuite::AesGcm128Sha256, key_id, KEY_MATERIAL)
-            .unwrap();
+        let (mut key_store, mut key_id) = key_store_with_key();
 
         key_id.inc_ratchet_step();
 
@@ -332,16 +321,8 @@ mod test {
     #[test]
     fn ratchets_forward_multiple_steps_at_once() {
         const STEPS: u64 = 3;
-        let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-        let mut step_by_step_store = RatchetingKeyStore::new(N_RATCHET_BITS);
-        let mut key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
-
-        key_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
-        step_by_step_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
+        let (mut key_store, mut key_id) = key_store_with_key();
+        let (mut step_by_step_store, _) = key_store_with_key();
 
         for _ in 0..STEPS {
             key_id.inc_ratchet_step();
@@ -352,21 +333,14 @@ mod test {
 
         assert_eq!(ratchet_steps, STEPS);
         let key = key_store.get_key(key_id).unwrap();
-        assert_eq!(
-            RatchetingKeyId::from_key_id(key.key_id(), N_RATCHET_BITS).ratchet_step(),
-            STEPS
-        );
+        assert_eq!(key.key_id(), KeyId::from(key_id));
         assert_eq!(key, step_by_step_store.get_key(key_id).unwrap());
     }
 
     #[test]
     fn rejects_ratcheting_beyond_the_maximum() {
         let mut key_store = RatchetingKeyStore::new(N_RATCHET_BITS).with_max_ratchet_steps(2);
-        let mut key_id = RatchetingKeyId::new(GENERATION, N_RATCHET_BITS);
-
-        key_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
+        let mut key_id = insert_key(&mut key_store, N_RATCHET_BITS);
         let key_before = key_store.get_key(key_id).unwrap().clone();
 
         for _ in 0..3 {
@@ -396,12 +370,7 @@ mod test {
     fn ratchets_on_ratcheting_step_overflow() {
         let n_ratchet_bits = 1;
         let mut key_store = RatchetingKeyStore::new(n_ratchet_bits);
-
-        let mut key_id = RatchetingKeyId::new(42u8, n_ratchet_bits);
-
-        key_store
-            .insert(CipherSuite::AesGcm256Sha512, key_id, KEY_MATERIAL)
-            .unwrap();
+        let mut key_id = insert_key(&mut key_store, n_ratchet_bits);
 
         key_id.inc_ratchet_step();
         key_store.try_ratchet(key_id).unwrap();

--- a/src/ratchet/ratcheting_key_store.rs
+++ b/src/ratchet/ratcheting_key_store.rs
@@ -67,6 +67,9 @@ where
     pub fn insert<K, M>(
         &mut self,
         cipher_suite: CipherSuite,
+        // TODO(v2): better parameter is the generation, as it is what matters. Currently it is not obvious that this
+        // replaces KeyIds with the same generation. Also a generation should always start at
+        // ratchet step 0.
         key_id: K,
         key_material: M,
     ) -> Result<()>
@@ -116,7 +119,8 @@ where
     /// Fails if more than [`RatchetingKeyStore::with_max_ratchet_steps`] steps would be needed.
     // TODO(v2): This method mustn't commit, a forged header could evict a valid key else wise. A
     // two step API is needed
-    // TODO(v2): improve the API, so it is easier to determine which was the KID ratched from
+    // TODO(v2): improve the API, so it is easier to determine which was the KID ratched from, also
+    // split the concerns
     pub fn try_ratchet<K>(&mut self, key_id: K) -> Result<u64>
     where
         K: Into<KeyId>,


### PR DESCRIPTION
`try_ratchet` used `Map::next_back`, which invokes the closure only once: the base key advanced a single step while `step_diff` was reported as performed. A receiver lagging more than one step derived a wrong key and failed decryption permanently.

## Changes

- **Derive every missed step**, and bound the catch up by a configurable maximum (`with_max_ratchet_steps`). The Ratchet Step comes from an unauthenticated header, so an unbounded catch up would allow up to `2^R - 1` key derivations per forged frame. The default is the full Ratchet Step range, i.e. it does not reject — choosing a bound that matches the expected loss and re-ordering is the caller's responsibility.
- **Clamp `n_ratchet_bits` to 63** in `RatchetingKeyStore::new`, as `RatchetingKeyId::new` already does. `RatchetingKeyStore::new(64)` previously panicked with a shift overflow on the first `insert`, reachable from configuration via `ReceiverOptions::n_ratchet_bits`.
- **Clamp `n_ratchet_bits` when parsing a key id** in `RatchetingKeyId::from_key_id`, which unlike `new` did not clamp, overflowing the shifts in `generation` / `ratchet_step`. Zero ratchet bits overflowed `inc_ratchet_step` too and is now a no-op.
- **Zeroize `RatchetingBaseKey`** on drop, so the current base key material does not outlive the store.
- Deduplicate the key store test setup.

## Notes

- `RatchetingBaseKey::ratchet` swaps material via `mem::replace`; the replaced `Vec` is dropped without zeroizing, so intermediate steps still hit the allocator in the clear. The derive only covers the final drop.

Closes #102
Closes #104

